### PR TITLE
♻️ Update Key creation and validation to use WP Form Reset Keys; ♻️ Update Forms to use WC Password Reset Form if template found; 🐛 Fixed bug where Sanitized characters would remain in output for notices.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ function custom_builtpass_password_reset_body( $body, $user_id ) {
 }
 
 ```
+## 1.3.0
+
+* Update Key creation and validation to use WP Form Reset Keys.
+* Update Forms to use WC Password Reset Form if template found.
+* Fixed bug where Sanitized characters would remain in output for notices.
+
 ## 1.2.1
 
 * Validate condition check for password reset page in enqueue method

--- a/builtmighty-password-reset.php
+++ b/builtmighty-password-reset.php
@@ -3,7 +3,7 @@
 Plugin Name: 🔑 Built Mighty Password Reset
 Plugin URI: https://builtmighty.com
 Description: Require users to reset their password on login or set a bulk reset for a specific user role.
-Version: 1.2.1
+Version: 1.3.0
 Author: Built Mighty
 Author URI: https://builtmighty.com
 Copyright: Built Mighty

--- a/inc/class-plugin.php
+++ b/inc/class-plugin.php
@@ -113,6 +113,7 @@ class builtpassPlugin {
         $this->loader->add_action( 'wp_login', $public, 'login_reset', 10, 2 );
         $this->loader->add_action( 'init', $public, 'redirect_timed_reset' );
         $this->loader->add_action( 'wp_logout', $public, 'logout' );
+        $this->loader->add_action( 'woocommerce_customer_reset_password', $public, 'handle_woocommerce_reset_password', 10, 1 );
 
         // Add filters.
         $this->loader->add_filter( 'template_include', $public, 'reset_password_template' );

--- a/private/class-private.php
+++ b/private/class-private.php
@@ -226,7 +226,7 @@ class builtpassPrivate {
                     if( isset( $data[ $key ] ) ) {
 
                         // Update.
-                        update_option( $key, $data[ $key ] );
+                        update_option( $key, sanitize_textarea_field( $data[ $key ] ) );
 
                     } else {
 
@@ -347,7 +347,7 @@ class builtpassPrivate {
             } elseif( $field['type'] == 'textarea' ) {
 
                 // Output textarea. ?>
-                <textarea name="<?php echo $key; ?>" id="<?php echo $key; ?>"><?php echo $value; ?></textarea><?php
+                <textarea name="<?php echo $key; ?>" id="<?php echo $key; ?>"><?php echo esc_textarea( wp_unslash( $value ) ); ?></textarea><?php
             
             } elseif( $field['type'] == 'submit' ) {
 

--- a/public/class-public.php
+++ b/public/class-public.php
@@ -322,4 +322,27 @@ class builtpassPublic {
 
     }
 
+    /**
+     * Handle WooCommerce reset password success.
+     * 
+     * @param WP_User $user The user object.
+     * 
+     * @return void
+     * 
+     * @since 1.3.0
+     * 
+     * @hook - action - woocommerce_customer_reset_password
+     */
+    public function handle_woocommerce_reset_password( $user ) {
+        // Prepare the data to mimic the builtpassProcess->run method.
+        $post = [
+            'user_id'  => $user->ID,
+            'password' => $user->user_pass, // The password is already set by WooCommerce.
+        ];
+
+        // Call save_password to update user meta and expire keys.
+        $process = new builtpassProcess();
+        $process->save_password( $post );
+    }
+
 }

--- a/public/views/reset-external.php
+++ b/public/views/reset-external.php
@@ -45,19 +45,36 @@ get_header();
 // Before external.
 do_action( 'builtpass_before_external', $_GET['user'] );
 
-// Reset form. ?>
-<div class="woocommerce-form woocommerce-form-reset reset">
-    <div class="built-password-reset">
-        <form id="built-password-reset-form" method="post">
-            <input type="hidden" name="action" value="builtpass_reset_password">
-            <input type="hidden" name="user_id" value="<?php echo $_GET['user']; ?>">
-            <input type="hidden" name="nonce" value="<?php echo wp_create_nonce( 'builtpass_reset_password' ); ?>">
-            <input type="password" name="password" placeholder="New password">
-            <input type="password" name="confirm_password" placeholder="Confirm new password">
-            <button type="submit">Reset password</button>
-        </form>
+$reset_password_template = 'myaccount/form-reset-password.php';
+
+// Check if WooCommerce Template Exists.
+if (
+    function_exists( 'wc_locate_template' ) &&
+    wc_locate_template( $reset_password_template )
+) {
+    // Get WooCommerce Reset Password Form
+    wc_get_template( $reset_password_template, [
+        'user'  => $_GET['user'],
+        'key'   => $_GET['key'],
+        'login' => $keys->get_login( $_GET['user'] ),
+    ]);
+} else {
+    // Reset form.
+    ?>
+    <div class="woocommerce-form woocommerce-form-reset reset">
+        <div class="built-password-reset">
+            <form id="built-password-reset-form" method="post">
+                <input type="hidden" name="action" value="builtpass_reset_password">
+                <input type="hidden" name="user_id" value="<?php echo $_GET['user']; ?>">
+                <input type="hidden" name="nonce" value="<?php echo wp_create_nonce( 'builtpass_reset_password' ); ?>">
+                <input type="password" name="password" placeholder="New password">
+                <input type="password" name="confirm_password" placeholder="Confirm new password">
+                <button type="submit">Reset password</button>
+            </form>
+        </div>
     </div>
-</div><?php
+    <?php
+}
 
 // After external.
 do_action( 'builtpass_after_external', $_GET['user'] );

--- a/public/views/reset-internal.php
+++ b/public/views/reset-internal.php
@@ -13,19 +13,40 @@ $process->run( $post, [ 'message' => '', 'redirect' => true ] );
 // Before internal.
 do_action( 'builtpass_before_internal', get_current_user_id() );
 
-// Reset form. ?>
-<div class="woocommerce-form woocommerce-form-reset reset">
-    <div class="built-password-reset">
-        <form id="built-password-reset-form" method="post">
-            <input type="hidden" name="action" value="builtpass_reset_password">
-            <input type="hidden" name="user_id" value="<?php echo get_current_user_id(); ?>">
-            <input type="hidden" name="nonce" value="<?php echo wp_create_nonce( 'builtpass_reset_password' ); ?>">
-            <input type="password" name="password" placeholder="New password">
-            <input type="password" name="confirm_password" placeholder="Confirm new password">
-            <button type="submit">Reset password</button>
-        </form>
+
+$reset_password_template = 'myaccount/form-reset-password.php';
+
+$user_id = get_current_user_id();
+
+// Check if WooCommerce Template Exists.
+if (
+    function_exists( 'wc_locate_template' ) &&
+    wc_locate_template( $reset_password_template )
+) {
+    $keys = isset( $keys ) ? $keys : new builtpassKeys();
+    // Get WooCommerce Reset Password Form
+    wc_get_template( $reset_password_template, [
+        'user'  => $user_id,
+        'key'   => $keys->get_key( $user_id ),
+        'login' => $keys->get_login( $user_id ),
+    ]);
+} else {
+    // Reset form.
+    ?>
+    <div class="woocommerce-form woocommerce-form-reset reset">
+        <div class="built-password-reset">
+            <form id="built-password-reset-form" method="post">
+                <input type="hidden" name="action" value="builtpass_reset_password">
+                <input type="hidden" name="user_id" value="<?php echo $user_id; ?>">
+                <input type="hidden" name="nonce" value="<?php echo wp_create_nonce( 'builtpass_reset_password' ); ?>">
+                <input type="password" name="password" placeholder="New password">
+                <input type="password" name="confirm_password" placeholder="Confirm new password">
+                <button type="submit">Reset password</button>
+            </form>
+        </div>
     </div>
-</div><?php
+    <?php
+}
 
 // After internal.
 do_action( 'builtpass_after_internal', get_current_user_id() );

--- a/public/views/reset-notice.php
+++ b/public/views/reset-notice.php
@@ -45,7 +45,7 @@ if( ! empty( get_option( 'builtpass_bulk_page' ) ) ) {
 
     // Output. ?>
     <div class="builtpass-notice-content">
-        <?php echo wpautop( get_option( 'builtpass_bulk_page' ) ); ?>
+        <?php echo wpautop( wp_unslash(  get_option( 'builtpass_bulk_page' ) ) ); ?>
     </div><?php 
 
 }

--- a/readme.txt
+++ b/readme.txt
@@ -20,6 +20,11 @@ This plugin includes both a timed password reset and a bulk password reset. The 
 == Screenshots ==
 
 == Changelog ==
+= 1.3.0 =
+* Update Key creation and validation to use WP Form Reset Keys.
+* Update Forms to use WC Password Reset Form if template found.
+* Fixed bug where Sanitized characters would remain in output for notices.
+
 = 1.2.1 =
 * Validate condition check for password reset page in enqueue method
 

--- a/utilities/class-keys.php
+++ b/utilities/class-keys.php
@@ -10,15 +10,22 @@ class builtpassKeys {
     /**
      * Create user key.
      * 
+     * @param int $user_id - The user ID.
+     * 
+     * @return string - The key.
+     * 
      * @since   1.0.0
+     * 
+     * @modified 1.3.0 - Added timestamp.
      */
     public function create_user_key( $user_id ) {
 
         // Create the key.
-        $key = $this->create_key();
+        $key = $this->create_key( $user_id );
 
         // Save the key.
         update_user_meta( $user_id, '_builtpass_key', $key );
+        update_user_meta( $user_id, '_builtpass_key_timestamp', time() );
 
         // Return.
         return $key;
@@ -28,12 +35,24 @@ class builtpassKeys {
     /**
      * Create key.
      * 
+     * @param int $user_id - The user ID.
+     * 
+     * @return string - The key.
+     * 
      * @since   1.0.0
+     * 
+     * @modified 1.3.0 - use get_password_reset_key.
      */
-    public function create_key() {
+    public function create_key( $user_id ) {
 
         // Create key.
-        $key = base64_encode( wp_generate_password( 32, false ) . ':' . time() );
+        // $key = base64_encode( wp_generate_password( 32, false ) . ':' . time() );
+
+        // Get the user object.
+        $user = get_user_by( 'id', $user_id );
+
+        // Generate the WordPress reset key.
+        $key = get_password_reset_key( $user );
 
         // Return key.
         return $key;
@@ -42,6 +61,10 @@ class builtpassKeys {
 
     /**
      * Get key.
+     * 
+     * @param int $user_id - The user ID.
+     * 
+     * @return string - The key.
      * 
      * @since   1.0.0
      */
@@ -56,29 +79,72 @@ class builtpassKeys {
     }
 
     /**
+     * Get login.
+     * 
+     * @param  int $user_id - The user ID.
+     * 
+     * @return string - The user login.
+     * 
+     * @since   1.3.0
+     */
+    public function get_login( $user_id ) {
+        $userdata = get_userdata( absint( $user_id ) );
+        $login    = $userdata ? $userdata->user_login : '';
+
+        // Return login.
+        return $login;
+    }
+
+    /**
+     * Check password reset key.
+     * 
+     * @param  string $key - The key to check.
+     * 
+     * @param  int $user_id - The user ID.
+     * 
+     * @since   1.3.0
+     */
+    public function check_password_reset_key( $key, $user_id ) {
+        $login = $this->get_login( $user_id );
+
+        return check_password_reset_key( $key, $login );
+    }
+
+    /**
      * Validate key.
      * 
+     * @param  string $post_key - The key from the post.
+     * @param  int $user_id - The user ID.
+     * 
+     * @return bool - Whether the key is valid.
+     * 
      * @since   1.0.0
+     * 
+     * @modified 1.3.0 - Added timestamp and use check_password_reset_key.
      */
-    public function validate( $key, $user_id ) {
+    public function validate( $post_key, $user_id ) {
 
-        // Decrypt key.
-        $post_key = $this->decrypt( $key );
+        // Get key timestamp.
+        $timestamp  = get_user_meta( $user_id, '_builtpass_key_timestamp', true );
 
         // Check if key expired within 24 hours.
-        if( $post_key[1] < strtotime( '-1 day' ) ) {
+        if( $timestamp < strtotime( '-1 day' ) ) {
 
             // Remove key.
             $this->expire( $user_id );
             return false;
 
         }
-        
+
         // Get user key.
-        $user_key = $this->decrypt( $this->get_key( $user_id ) );
+        // $user_key = $this->decrypt( $this->get_key( $user_id ) );
+        $user_key = $this->get_key( $user_id );
+
+        // Ensure Password Reset Key is valid
+        if( ! $this->check_password_reset_key( $post_key, $user_id ) ) return false;
 
         // Check if key expired within 24 hours.
-        if( $user_key[1] < strtotime( '-1 day' ) ) {
+        if( $timestamp < strtotime( '-1 day' ) ) {
 
             // Remove key.
             $this->expire( $user_id );
@@ -87,7 +153,7 @@ class builtpassKeys {
         }
 
         // Compare keys.
-        if( $user_key[0] !== $post_key[0] ) return false;
+        if( $user_key !== $post_key ) return false;
 
         // Keys are valid.
         return true;
@@ -96,6 +162,10 @@ class builtpassKeys {
 
     /**
      * Decrypt key.
+     * 
+     * @param  string $key - The key to decrypt.
+     * 
+     * @return array - The decrypted key.
      * 
      * @since   1.0.0
      */
@@ -109,12 +179,19 @@ class builtpassKeys {
     /**
      * Expire key.
      * 
+     * @param  int $user_id - The user ID.
+     * 
+     * @return void
+     * 
      * @since   1.0.0
      */
     public function expire( $user_id ) {
 
         // Delete key from user.
         delete_user_meta( $user_id, '_builtpass_key' );
+
+        // Delete key timestamp.
+        delete_user_meta( $user_id, '_builtpass_key_timestamp' );
 
     }
 


### PR DESCRIPTION
## What Type of Change is This?
- [x] 🐛 Bug fix
- [x] ♻️ Change or Refactor to Existing Feature

---

## 🔎 Overview 
### [VAL-686](https://builtmighty.atlassian.net/browse/VAL-686)

This pull request includes updates to the `Built Mighty Password Reset` plugin, focusing on enhancing WooCommerce integration, improving security, and adding new functionalities for password reset management.

### WooCommerce Integration:
* Added a new action `woocommerce_customer_reset_password` to handle WooCommerce password reset events (`inc/class-plugin.php`).
* Implemented a method `handle_woocommerce_reset_password` to process WooCommerce password reset and update user meta (`public/class-public.php`).
* Updated views to use WooCommerce reset password form if available (`public/views/reset-external.php`, `public/views/reset-internal.php`). [[1]](diffhunk://#diff-c9165b412bef88d1c1a058953e64e4e07b5ef9c8c7ef74b8f88a05f4e0359f71L48-R63) [[2]](diffhunk://#diff-c9165b412bef88d1c1a058953e64e4e07b5ef9c8c7ef74b8f88a05f4e0359f71L60-R77) [[3]](diffhunk://#diff-5f0c5bd521b1aecfc1af94d7f3b90cd7620bda65ed3623f4c13d558099d662efL16-R49)

### Security Improvements:
* Sanitized input data in the `save` method to prevent potential security issues (`private/class-private.php`).
* Escaped textarea output in the `get_field` method to ensure safe rendering (`private/class-private.php`).
* Added `wp_unslash` to `wpautop` in `reset-notice.php` to ensure proper handling of slashed data (`public/views/reset-notice.php`).

### Password Reset Key Management:
* Modified the `create_user_key` method to include a timestamp and use WordPress's `get_password_reset_key` function (`utilities/class-keys.php`). [[1]](diffhunk://#diff-1a07f4803ba23d3940660b5bbd4685e7d76439989aa0595a3f46093f75eb8b9fR13-R28) [[2]](diffhunk://#diff-1a07f4803ba23d3940660b5bbd4685e7d76439989aa0595a3f46093f75eb8b9fR38-R55)
* Added methods to get user login, check password reset key, and validate keys using timestamps (`utilities/class-keys.php`). [[1]](diffhunk://#diff-1a07f4803ba23d3940660b5bbd4685e7d76439989aa0595a3f46093f75eb8b9fR65-R68) [[2]](diffhunk://#diff-1a07f4803ba23d3940660b5bbd4685e7d76439989aa0595a3f46093f75eb8b9fR81-R131) [[3]](diffhunk://#diff-1a07f4803ba23d3940660b5bbd4685e7d76439989aa0595a3f46093f75eb8b9fL78-R147) [[4]](diffhunk://#diff-1a07f4803ba23d3940660b5bbd4685e7d76439989aa0595a3f46093f75eb8b9fL90-R156)
* Updated the `expire` method to delete the key timestamp (`utilities/class-keys.php`).

### Version Update:
* Updated the plugin version to 1.3.0 to reflect the new features and improvements (`builtmighty-password-reset.php`).

---

### 📖 Git Flow Reference
```mermaid
flowchart LR
    A[[feature/1234_branch]] --> B{{Merge via PR}}
    B --> C[[rc/x.x.x]]
    C --> D{Run CI/CD?}
    D -->|fa:fa-x Fail Code Checks| E[Commit Fixes] --> D
    D -->|fa:fa-check Pass Code Checks| F[Merge Commit]
    F --> G{ Q/A }
    G --> H{{Merge via PR}}
    H --> I[[main]]
```





[VAL-686]: https://builtmighty.atlassian.net/browse/VAL-686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ